### PR TITLE
Render task with css if in web view

### DIFF
--- a/src/Factory/SeederFixtureFactory.php
+++ b/src/Factory/SeederFixtureFactory.php
@@ -3,6 +3,7 @@
 namespace Werkbot\Seeder;
 /**/
 use SilverStripe\AssetAdmin\Controller\AssetAdmin;
+use SilverStripe\Core\Environment;
 use SilverStripe\Assets\Folder;
 use SilverStripe\Assets\Image;
 use SilverStripe\Dev\FixtureBlueprint;
@@ -60,7 +61,11 @@ class SeederFixtureFactory extends FixtureFactory {
 
         $obj->publishRecursive();
 
-        echo $identifier . ' created. <br>';
+        if(!Environment::isCli()){
+            echo '<li class="info">' . $identifier . ' created.</li>';
+        } else {
+            echo ' - ' . $identifier . ' created.' . PHP_EOL;
+        }
 
         return $obj;
     }


### PR DESCRIPTION
https://werkbotstudios.teamwork.com/#/tasks/28036407

### Summary
- Render seeder task lists with css if in web view
- Format seeder task list if using sake (cli)
- Beautified php file

### Testing
- [x] test with a fresh site install (this generates a lot of data)
- [x] run a single seeder in the web view, confirm this looks good (same stylesheet as dev/build)
- [x] run a single seeder with sake or (`vendor/silverstripe/framework/sake`), confirm this looks good (no html tags)
- [x] in the web view, run the "Generate Development Test Data" seeder `dev/tasks/Werkbot-Seeder-SeederBuildTask`, confirm this looks good, and the individual seeder are split up
- [x] run `vendor/silverstripe/framework/sake dev/tasks/Werkbot-Seeder-SeederBuildTask`, confirm the individual seeders look good here as well