### PR TITLE
Directory corrections

### DIFF
--- a/src/Tasks/SeederBuildTask.php
+++ b/src/Tasks/SeederBuildTask.php
@@ -8,87 +8,95 @@ use SilverStripe\Core\Environment;
 use Symfony\Component\Yaml\Parser;
 use SilverStripe\Core\Injector\Injector;
 /**/
-class SeederBuildTask extends BuildTask {
-	/**/
-	protected $title = 'Generate Development Test Data';
-	protected $description = 'Generate development test data. Reduces the time it takes to test a newly installed site.';
-	protected $enabled = true;
-	/**/
-	protected $fixtureFileName = 'DatabaseSeeder.yml';
-	/**/
-	public function run($request)
-	{
-		// Used to get contents of DatabaseSeeder.yml override
-		$pathResolver = '';
-		// Only run in a dev or test environment
-		if(Environment::getEnv('SS_ENVIRONMENT_TYPE') == 'dev'
-			|| Environment::getEnv('SS_ENVIRONMENT_TYPE') == 'test'
-		) {
-			// Get the directory of the current seeder build task
-			$seederTaskDirectory = (new \ReflectionClass(get_class($this)))->getFilename();
-			$seederTaskDirectory = explode('/', $seederTaskDirectory);
-			// If the directory is not split by forward slashes, split by Windows back slashes
-			if(count($seederTaskDirectory) == 1){
-				$seederTaskDirectory = explode('\\', join($seederTaskDirectory));
-			}
-			array_pop($seederTaskDirectory);
-			$seederTaskDirectory = join('/', $seederTaskDirectory);
+class SeederBuildTask extends BuildTask
+{
+    /**/
+    protected $title = 'Generate Development Test Data';
+    protected $description = 'Generate development test data. Reduces the time it takes to test a newly installed site.';
+    protected $enabled = true;
+    /**/
+    protected $fixtureFileName = 'DatabaseSeeder.yml';
+    /**/
+    public function run($request)
+    {
+        // Used to get contents of DatabaseSeeder.yml override
+        // Only run in a dev or test environment
+        if (Environment::getEnv('SS_ENVIRONMENT_TYPE') == 'dev'
+            || Environment::getEnv('SS_ENVIRONMENT_TYPE') == 'test'
+        ) {
+            // Get site root. Set to the current directory if running through command line.
+            $siteRoot = $_SERVER['DOCUMENT_ROOT'] ? $_SERVER['DOCUMENT_ROOT'] . '/..' : getcwd();
 
-			// Check in the site if a fixture override exists
-			if(file_exists('../app/seeds/' . $this->fixtureFileName)) {
-				$fixtureFile = 'app/seeds/' . $this->fixtureFileName;
-				$pathResolver = '../';
-			} else if(file_exists('../app/_config/' . $this->fixtureFileName)) {
-				$fixtureFile = 'app/_config/' . $this->fixtureFileName;
-				$pathResolver = '../';
-			} else if(file_exists('../mysite/seeds/' . $this->fixtureFileName)) {
-				$fixtureFile = 'mysite/seeds/' . $this->fixtureFileName;
-				$pathResolver = '../';
-			} else if(file_exists('../mysite/_config/' . $this->fixtureFileName)) {
-				$fixtureFile = 'mysite/_config/' . $this->fixtureFileName;
-				$pathResolver = '../';
+            // Get the directory of the current seeder build task
+            $seederTaskDirectory = (new \ReflectionClass(get_class($this)))->getFilename();
 
-			// Check in the current seeder's module if a fixture override exists
-			} else if(file_exists($seederTaskDirectory . '/../../seeds/' . $this->fixtureFileName)) {
-				$fixtureFile = $seederTaskDirectory . '/../../seeds/' . $this->fixtureFileName;
-			} else if(file_exists($seederTaskDirectory . '/../../_config/' . $this->fixtureFileName)) {
-				$fixtureFile = $seederTaskDirectory . '/../../_config/' . $this->fixtureFileName;
+            // Split path to seeder task into individual directories. Used to find the seeder project directory.
+            $seederTaskDirectories = explode('/', $seederTaskDirectory);
+            // If the directory is not split by forward slashes, split by Windows back slashes
+            if (count($seederTaskDirectories) == 1) {
+                $seederTaskDirectories = explode('\\', join($seederTaskDirectories));
+            }
+            array_pop($seederTaskDirectories);
 
-			// Check if default fixture exists
-			} else if(file_exists(__DIR__ . '/../Fixtures/' . $this->fixtureFileName)) {
-				$fixtureFile = __DIR__ . '/../Fixtures/' . $this->fixtureFileName;
-			} else {
-				echo 'No fixture file found. Create an "app/seeds/$fixtureFileName"';
-				return;
-			}
+            // Find the root directory of the project the seeder task lives in. This could be the site or a module.
+            $seederTaskProjectDirectories = [];
+            foreach ($seederTaskDirectories as $directoryIndex => $directoryName) {
+                array_push($seederTaskProjectDirectories, $directoryName);
+                if (preg_match('/app|mysite|vendor/', $directoryName)) {
+                    array_push($seederTaskProjectDirectories, $seederTaskDirectories[$directoryIndex + 1]);
+                    if ($directoryName == 'vendor') {
+                        array_push($seederTaskProjectDirectories, $seederTaskDirectories[$directoryIndex + 2]);
+                    }
+                    break;
+                }
+            }
+            $seederTaskProjectDirectory = join('/', $seederTaskProjectDirectories);
 
-			// If running the parent SeederBuildTask
-			if($this->fixtureFileName == 'DatabaseSeeder.yml'){
-				$parser = new Parser();
-	            $contents = file_get_contents($pathResolver . $fixtureFile);
-	            $fixtureContent = $parser->parse($contents);
-	            // Run enabled seeder classes
-	            foreach($fixtureContent as $seederClass => $options){
-	            	if($options['enabled']){
-	            		echo 'Running ' . $seederClass . '. <br>';
-	            		Injector::inst()->create($seederClass)->run($request);
-	            		echo '<br>';
-	            	}
-	            }
-			} else {
-				// Run singular seeder
-				$fixture = YamlFixture::create($fixtureFile);
-				if(method_exists($this, 'createObjectCallback')){
-					$createObjectCallback = function($obj, $class, $data){
-						call_user_func([$this, 'createObjectCallback'], $obj, $class, $data);
-					};
-					$fixture->writeInto(new SeederFixtureFactory($createObjectCallback));
-				} else {
-					$fixture->writeInto(new SeederFixtureFactory());
-				}
-			}
-		} else {
-			echo 'Must run in development or test environment';
-		}
-	}
+            // Check in the site if a fixture override exists
+            if (file_exists($siteRoot . '/app/seeds/' . $this->fixtureFileName)) {
+                $fixtureFile = $siteRoot . '/app/seeds/' . $this->fixtureFileName;
+            } else if (file_exists($siteRoot . '/mysite/seeds/' . $this->fixtureFileName)) {
+                $fixtureFile = $siteRoot . '/mysite/seeds/' . $this->fixtureFileName;
+
+            // Check if module fixture exists
+            } else if (file_exists($seederTaskProjectDirectory . '/seeds/' . $this->fixtureFileName)) {
+                $fixtureFile = $seederTaskProjectDirectory . '/seeds/' . $this->fixtureFileName;
+
+            // Check if default fixture exists
+            } else if (file_exists($seederTaskProjectDirectory . '/src/Fixtures/' . $this->fixtureFileName)) {
+                $fixtureFile = $seederTaskProjectDirectory . '/src/Fixtures/' . $this->fixtureFileName;
+            } else {
+                echo 'No fixture file found. Create an "app/seeds/$fixtureFileName"';
+                return;
+            }
+
+            // If running the parent SeederBuildTask
+            if ($this->fixtureFileName == 'DatabaseSeeder.yml') {
+                $parser = new Parser();
+                $contents = file_get_contents($fixtureFile);
+                $fixtureContent = $parser->parse($contents);
+                // Run enabled seeder classes
+                foreach ($fixtureContent as $seederClass => $options) {
+                    if ($options['enabled']) {
+                        echo 'Running ' . $seederClass . '. <br>';
+                        Injector::inst()->create($seederClass)->run($request);
+                        echo '<br>';
+                    }
+                }
+            } else {
+                // Run singular seeder
+                $fixture = YamlFixture::create($fixtureFile);
+                if (method_exists($this, 'createObjectCallback')) {
+                    $createObjectCallback = function ($obj, $class, $data) {
+                        call_user_func([$this, 'createObjectCallback'], $obj, $class, $data);
+                    };
+                    $fixture->writeInto(new SeederFixtureFactory($createObjectCallback));
+                } else {
+                    $fixture->writeInto(new SeederFixtureFactory(null));
+                }
+            }
+        } else {
+            echo 'Must run in development or test environment';
+        }
+    }
 }


### PR DESCRIPTION
https://werkbotstudios.teamwork.com/#/tasks/28071449

### Summary
- Updated the way fixture files are located. This used to to search relatively from the build task file itself. Now, this should look for the project root directory (module or site), and look inside a "seeds" directory there. The build task can now be placed anywhere in the project, and the appropriate fixture should still be found. Valid fixture locations are as follows:
  - app/seeds
  - vendor/packagevendor/modulename/seeds
- Gets the correct site root in both the web and cli versions of the task. The site root is used to prioritize override fixtures. Overrides were not working in the CLI version.

### Testing
- [x] `dev/build`
- [x] test each of the following in both the web task, and the cli: `vendor/silverstripe/framework/sake dev/tasks/Werkbot-Seeder-SeederBuildTask`
- [x] delete or rename the navigation page seeder override, run seeder (for both versions) and confirm the default fixture still works
- [x] restore the override and alter it so it is distinct from the default, run and confirm this works
- [x] install a module with a seeder (I did the calendar)
- [x] confirm the default works, override the fixture on your site and confirm this works too
- [x] create a seeder task anywhere on your site (e.g. `app/seeds/ExamplePageSeeder.php`, but it should work anywhere in "app")
- [x] create a fixture for it in app/seeds, confirm this works
- [x] run the base "Generate Development Test Data" seeder `dev/tasks/Werkbot-Seeder-SeederBuildTask`, with the default and the override, confirm this works

### Concern
The CLI version of the build task shows html tags. This is covered here https://github.com/werkbot/silverstripe-module-seeder/pull/10