### PR TITLE
feature: Added automatic draft release and changelog updater

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,31 @@
+name-template: '$RESOLVED_VERSION'
+tag-template: '$RESOLVED_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: '🧰 Maintenance'
+    label: 'chore'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+template: |
+  ## What’s Changed
+
+  $CHANGES

--- a/.github/tag-changelog-config.js
+++ b/.github/tag-changelog-config.js
@@ -1,0 +1,32 @@
+module.exports = {
+  types: [
+    { types: ["feat", "feature"], label: "🎉 New Features" },
+    { types: ["fix", "bugfix", "bug"], label: "🐛 Bugfixes" },
+    { types: ["improvements", "enhancement"], label: "🔨 Improvements" },
+    { types: ["perf"], label: "🏎️ Performance Improvements" },
+    { types: ["build", "ci"], label: "🏗️ Build System" },
+    { types: ["refactor"], label: "🪚 Refactors" },
+    { types: ["doc", "docs"], label: "📚 Documentation Changes" },
+    { types: ["test", "tests"], label: "🔍 Tests" },
+    { types: ["style"], label: "💅 Code Style Changes" },
+    { types: ["chore"], label: "🧹 Chores" },
+    { types: ["other"], label: "Other Changes" },
+  ],
+
+  excludeTypes: ["other"],
+
+  renderTypeSection: function (label, commits) {
+    let text = `\n## ${label}\n`;
+
+    commits.forEach((commit) => {
+      text += `- ${commit.subject}\n`;
+    });
+
+    return text;
+  },
+
+  renderChangelog: function (release, changes) {
+    const now = new Date();
+    return `## ${release} - ${now.toISOString().substr(0, 10)}\n` + changes + "\n\n";
+  },
+};

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,33 @@
+name: Generate Changelog
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  update_changelog:
+    runs-on: ubuntu-latest
+    outputs:
+      output: ${{ steps.changelog.outputs.changelog }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: main
+      - name: Generate Changelog
+        id: changelog
+        uses: loopwerk/tag-changelog@v1.0.4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          exclude_types: other,doc,chore
+          config_file: .github/tag-changelog-config.js
+      - name: Output Changelog
+        id: output_changelog
+        run: TAGCONTENT="${{ steps.changelog.outputs.changelog }}";CHANGELOG=$(cat CHANGELOG.md);CHANGELOG=$(echo "$CHANGELOG" | sed -e "s/# Changelog//");echo -e "# Changelog\n\n$TAGCONTENT$CHANGELOG" > CHANGELOG.md
+      - name: Commit Updated Changelog
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Updated CHANGELOG.md

--- a/.github/workflows/draftrelease.yml
+++ b/.github/workflows/draftrelease.yml
@@ -1,0 +1,20 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Draft Release
+        uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
https://werkbotstudios.teamwork.com/#/tasks/28316154

### Summary
Added automatic draft release and changelog updater. When a pr is merged with labels, a release draft will automatically be generated and sorted based on labels. When the release is published, the changelog file will be updated.

### Testing Steps
- [x] fork this repo
- [x] create a pr for your fork, be sure to commit with a "type: " in your message
- [x] add the corresponding label to your pr (this is used by the draft release action), you may add more than one label too
- [ ] merge your pr into your fork's main branch
- [ ] confirm a draft release was generated
- [ ] publish the release
- [ ] confirm the changelog file is updated and shows changes based on your commit type
- [ ] (optional) test merging multiple PRs with various types of changes before releasing
- [ ] (optional) use a "major" label in a PR, confirm the draft PR automatically increments the major version

### Issues/Concerns
- The first commit message of every pr must begin with a "type", for the changelog action to work (see "feature: " above). See [commit types here](https://github.com/werkbot/silverstripe-module-seeder/blob/automated-release-and-changelog/.github/tag-changelog-config.js#L2).
- Be sure to check the "Actions" tab in your repo, especially if something doesn't work right.
- I'm fairly certain all of the above will happen to this repo when this PR is merged and released as well.
- My test fork: https://github.com/tiller1010/silverstripe-module-seeder