### PR TITLE
feat: seeder settings, enable/disable seeder

### DIFF
--- a/src/SeederHistory/SeederAdmin.php
+++ b/src/SeederHistory/SeederAdmin.php
@@ -4,6 +4,9 @@ namespace Werkbot\Seeder\SeederHistory;
 
 use SilverStripe\Admin\ModelAdmin;
 use SilverStripe\Core\Environment;
+use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\Form;
+use SilverStripe\Forms\FormAction;
 use SilverStripe\Forms\GridField\GridFieldButtonRow;
 use SilverStripe\Forms\GridField\GridFieldConfig;
 use SilverStripe\Forms\GridField\GridFieldDataColumns;
@@ -14,12 +17,17 @@ use SilverStripe\Forms\GridField\GridFieldFilterHeader;
 use SilverStripe\Forms\GridField\GridFieldSortableHeader;
 use SilverStripe\Forms\GridField\GridField_ActionMenu;
 use SilverStripe\Forms\HeaderField;
+use SilverStripe\View\Requirements;
+use Werkbot\Seeder\Settings\SeederSettings;
 
 class SeederAdmin extends ModelAdmin
 {
   private static $managed_models = [
+    SeederSettings::class => [
+      'title' => 'Settings',
+    ],
     SeedObject::class => [
-      'title' => 'Seeder History'
+      'title' => 'History'
     ],
   ];
 
@@ -29,39 +37,91 @@ class SeederAdmin extends ModelAdmin
 
   public function getEditForm($id = null, $fields = null)
   {
+    $modelClass = $this->modelClass;
+
+    if ($modelClass == SeederSettings::class) {
+      Requirements::customCSS(<<<CSS
+        .cms .cms-panel-padded .cms-content-view {
+          padding: 0;
+        }
+      CSS);
+
+      $seederSettings = SeederSettings::currentSeederSettings();
+      $form = Form::create(
+        $this,
+        'EditForm',
+        $seederSettings->getCMSFields(),
+        FieldList::create(
+          FormAction::create(
+            'save_settings',
+            _t('SilverStripe\\CMS\\Controllers\\CMSMain.SAVE', 'Save')
+          )->addExtraClass('btn-primary font-icon-save')
+        )
+      )->setHTMLID('Form_EditForm');
+      $form->addExtraClass('flexbox-area-grow fill-height cms-content cms-edit-form');
+      $form->loadDataFrom($seederSettings);
+      $form->setTemplate('SilverStripe/SiteConfig/Includes/SiteConfigLeftAndMain_EditForm');
+
+      $this->extend('updateEditForm', $form);
+
+      return $form;
+
+    }
+
     $form = parent::getEditForm($id, $fields);
 
     $form->fields()->insertBefore(
-      $this->sanitiseClassName($this->modelClass),
+      $this->sanitiseClassName($modelClass),
       HeaderField::create('Remove generated data by deleting the associated seed.')
     );
 
-    $gridField = $form->fields()->fieldByName($this->sanitiseClassName($this->modelClass));
+    $gridField = $form->fields()->fieldByName($this->sanitiseClassName($modelClass));
 
     $config = GridFieldConfig::create();
     $config->addComponent(new GridFieldButtonRow('before'))
-           ->addComponent(new GridFieldDataColumns())
-           ->addComponent(new GridFieldSortableHeader())
-           ->addComponent(new GridFieldFilterHeader())
-           ->addComponent(new GridFieldEditButton())
-           ->addComponent((new GridFieldDetailForm())->setShowAdd(false))
-           ->addComponent(new GridField_ActionMenu())
-           ->addComponent(new GridFieldDeleteAction());
+      ->addComponent(new GridFieldDataColumns())
+      ->addComponent(new GridFieldSortableHeader())
+      ->addComponent(new GridFieldFilterHeader())
+      ->addComponent(new GridFieldEditButton())
+      ->addComponent((new GridFieldDetailForm())->setShowAdd(false))
+      ->addComponent(new GridField_ActionMenu())
+      ->addComponent(new GridFieldDeleteAction());
 
     $gridField->setConfig($config);
 
     return $form;
   }
 
+  /**
+   * Save the current sites {@link SeederSettings} into the database.
+   *
+   * @param array $data
+   * @param Form $form
+   * @return String
+   */
+  public function save_settings($data, $form)
+  {
+    $seederSettings = SeederSettings::currentSeederSettings();
+    $form->saveInto($seederSettings);
+    $seederSettings->write();
+    $this->response->addHeader(
+      'X-Status',
+      rawurlencode(_t('SilverStripe\\Admin\\LeftAndMain.SAVEDUP', 'Saved.'))
+    );
+    return $form->forTemplate();
+  }
+
   public function canView($member = null)
   {
     $canView = parent::canView($member = null);
-        /*
-            Only show seeder admin if in a dev or test environment
-         */
+
+    /*
+      Only show seeder admin if in a dev or test environment
+     */
     if (!(Environment::getEnv('SS_ENVIRONMENT_TYPE') == 'dev' || Environment::getEnv('SS_ENVIRONMENT_TYPE') == 'test')) {
       $canView = false;
     }
+
     return $canView;
   }
 

--- a/src/Settings/SeederSettings.php
+++ b/src/Settings/SeederSettings.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Werkbot\Seeder\Settings;
+
+use SilverStripe\Forms\CheckboxField;
+use SilverStripe\Forms\FieldGroup;
+use SilverStripe\Forms\FieldList;
+use SilverStripe\ORM\DB;
+use SilverStripe\ORM\DataObject;
+
+class SeederSettings extends DataObject
+{
+  private static $table_name = 'SeederSettings';
+
+  private static $db = [
+    'Enabled' => 'Boolean',
+  ];
+
+  public function getCMSFields()
+  {
+    return FieldList::create(
+      FieldGroup::create(
+        'Enable seeder?',
+        CheckboxField::create('Enabled', 'Enable')
+      )
+    );
+  }
+
+  /**
+   * Get the current sites SeederSettings, and creates a new one through
+   * {@link createSeederSettings()} if none is found.
+   *
+   * @return SeederSettings
+   */
+  public static function currentSeederSettings(): SeederSettings
+  {
+    $seederSettings = DataObject::get_one(SeederSettings::class);
+    if (!$seederSettings) {
+      $seederSettings = SeederSettings::createSeederSettings();
+    }
+
+    static::singleton()->extend('updateCurrentSeederSettings', $seederSettings);
+
+    return $seederSettings;
+  }
+
+  /**
+   * Setup a default SeederSettings record if none exists.
+   */
+  public function requireDefaultRecords()
+  {
+    parent::requireDefaultRecords();
+
+    $seederSettings = DataObject::get_one(SeederSettings::class);
+
+    if (!$seederSettings) {
+      SeederSettings::createSeederSettings();
+
+      DB::alteration_message('Added seeder settings', 'created');
+    }
+  }
+
+  /**
+   * Create SeederSettings
+   *
+   * @return SeederSettings
+   */
+  public static function createSeederSettings(): SeederSettings
+  {
+    $seederSettings = SeederSettings::create();
+    $seederSettings->write();
+
+    return $seederSettings;
+  }
+
+}
+

--- a/src/Tasks/SeederBuildTask.php
+++ b/src/Tasks/SeederBuildTask.php
@@ -10,6 +10,7 @@ use SilverStripe\Dev\YamlFixture;
 use Symfony\Component\Yaml\Parser;
 use Werkbot\Seeder\Factory\SeederFixtureFactory;
 use Werkbot\Seeder\SeederHistory\SeedObject;
+use Werkbot\Seeder\Settings\SeederSettings;
 
 class SeederBuildTask extends BuildTask
 {
@@ -21,6 +22,11 @@ class SeederBuildTask extends BuildTask
 
   public function run($request)
   {
+    if (!SeederSettings::currentSeederSettings()->Enabled) {
+      echo 'Must enable seeder in the CMS: /admin/seeder/Werkbot-Seeder-Settings-SeederSettings';
+      return;
+    }
+
     // Only run in a dev or test environment
     if (Environment::getEnv('SS_ENVIRONMENT_TYPE') == 'dev'
       || Environment::getEnv('SS_ENVIRONMENT_TYPE') == 'test'


### PR DESCRIPTION
https://werkbotstudios.teamwork.com/app/tasks/38070110
https://werkbotstudios.teamwork.com/app/tasks/38070170

### Summary
- Added seeder settings to seeder admin
- Prevented seeder from running if not enabled

### Testing Steps
- [x] dev/build
- [x] confirm the seeder settings work well
- [x] confirm the seeders cannot run if the seeder is not enabled

### Issues/Concerns
- We may be able to switch to a "SingleRecordAdmin" in SS6, but it may make more sense to keep module settings with the existing model admins. Thoughts?

### Git Flow
- **DO NOT** delete "release/\*" or "hotfix/\*" branches after merging a PR. These are used to publish the next release, and they are deleted automatically.
- "Squash and merge" is good on "feature/\*" into "develop"
- "Create a merge commit" is good on "release/\*" or "hotfix/\*" into "main"
